### PR TITLE
ESP32-S2 platform support

### DIFF
--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -34,6 +34,13 @@ ESP32Encoder::~ESP32Encoder() {
  * and pass this information together with the event type
  * the main program using a queue.
  */
+#ifdef CONFIG_IDF_TARGET_ESP32S2
+	#define COUNTER_H_LIM cnt_thr_h_lim_lat_un
+	#define COUNTER_L_LIM cnt_thr_l_lim_lat_un
+#else
+	#define COUNTER_H_LIM h_lim_lat
+	#define COUNTER_L_LIM counter_l_lim
+#endif
 static void IRAM_ATTR pcnt_example_intr_handler(void *arg) {
 	ESP32Encoder * ptr;
 
@@ -47,10 +54,10 @@ static void IRAM_ATTR pcnt_example_intr_handler(void *arg) {
 			 to pass it to the main program */
 
 			int64_t status=0;
-			if(PCNT.status_unit[i].h_lim_lat){
+			if(PCNT.status_unit[i].COUNTER_H_LIM){
 				status=ptr->r_enc_config.counter_h_lim;
 			}
-			if(PCNT.status_unit[i].l_lim_lat){
+			if(PCNT.status_unit[i].COUNTER_L_LIM){
 				status=ptr->r_enc_config.counter_l_lim;
 			}
 			//pcnt_counter_clear(ptr->unit);

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -13,9 +13,7 @@
 //
 //
 enum puType ESP32Encoder::useInternalWeakPullResistors=DOWN;
-ESP32Encoder *ESP32Encoder::encoders[MAX_ESP32_ENCODERS] = { NULL, NULL, NULL,
-	NULL,
-	NULL, NULL, NULL, NULL };
+ESP32Encoder *ESP32Encoder::encoders[MAX_ESP32_ENCODERS] = { NULL };
 
 bool ESP32Encoder::attachedInterrupt=false;
 pcnt_isr_handle_t ESP32Encoder::user_isr_handle = NULL;

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -13,7 +13,7 @@
 //
 //
 enum puType ESP32Encoder::useInternalWeakPullResistors=DOWN;
-ESP32Encoder *ESP32Encoder::encoders[MAX_ESP32_ENCODERS] = { NULL };
+ESP32Encoder *ESP32Encoder::encoders[MAX_ESP32_ENCODERS] = { NULL, };
 
 bool ESP32Encoder::attachedInterrupt=false;
 pcnt_isr_handle_t ESP32Encoder::user_isr_handle = NULL;

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -39,7 +39,7 @@ ESP32Encoder::~ESP32Encoder() {
 	#define COUNTER_L_LIM cnt_thr_l_lim_lat_un
 #else
 	#define COUNTER_H_LIM h_lim_lat
-	#define COUNTER_L_LIM counter_l_lim
+	#define COUNTER_L_LIM l_lim_lat
 #endif
 static void IRAM_ATTR pcnt_example_intr_handler(void *arg) {
 	ESP32Encoder * ptr;


### PR DESCRIPTION
This PR adresses two issues in order to make this package compatible with the ESP32-S2 platform.

- Hard-coded initializer for 'encoders' array will fail on platforms, where MAX_ESP32_ENCODERS is not 8:
```
Fixed bug, where the encoders array was hard-coded initialized to be 8 times NULL.
When running on a platform like ESP32-S2, where MAX_ESP32_ENCODERS is 4, the former limit caused a compile-error.
Changed initializer-list to { NULL } to cover arbitrary amount of encoders
```
- Compile error for ESP32-S2 due to variable-refactoring on esp32-arduino framework
```
Fixed compile error on ESP32-S2 platform as reported here https://github.com/madhephaestus/ESP32Encoder/issues/51
```