### PR TITLE
Add possibility to use interrupts on every pulse and set a callback

### DIFF
--- a/examples/Encoder/Encoder_interrupt_display.cpp
+++ b/examples/Encoder/Encoder_interrupt_display.cpp
@@ -1,0 +1,64 @@
+#include <Arduino.h>
+#include <ESP32Encoder.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#include "esp_task_wdt.h"
+
+static IRAM_ATTR void enc_cb(ESP32Encoder* enc) {
+  Serial.printf("enc cb: count: %d\n", enc->getCount());
+  static bool leds = false;
+  digitalWrite(LED_BUILTIN, (int)leds);
+  leds = !leds;
+}
+
+extern bool loopTaskWDTEnabled;
+extern TaskHandle_t loopTaskHandle;
+
+ESP32Encoder encoder(true, enc_cb);
+Adafruit_SSD1306 display(128, 32, &Wire);
+
+static const char* LOG_TAG = "main";
+
+void setup(){
+  loopTaskWDTEnabled = true;
+  pinMode(LED_BUILTIN, OUTPUT);
+  Serial.begin(115200);
+  // Encoder A and B pins connected with 1K series resistor to pins 4 and 5, common pin to ground.
+  //         |- A   --- 1K --- pin 4
+  //  >=[enc]|- GND
+  //         |- B   --- 1K --- pin 5
+
+  ESP32Encoder::useInternalWeakPullResistors=UP;
+  encoder.attachSingleEdge(4, 5);
+  encoder.clearCount();
+  encoder.setFilter(1023);
+
+  if (! display.begin(SSD1306_SWITCHCAPVCC, 0x3c))
+  {
+    for (;;) {
+      Serial.println("display init failed");
+    }
+  }
+  display.cp437(true);
+  display.clearDisplay();
+  display.setTextSize(2);
+  display.setTextColor(WHITE);
+  display.setCursor(0,0);
+  display.display();
+  esp_log_level_set("*", ESP_LOG_DEBUG);
+  esp_log_level_set("main", ESP_LOG_DEBUG);
+  esp_log_level_set("ESP32Encoder", ESP_LOG_DEBUG);
+
+  esp_task_wdt_add(loopTaskHandle);
+}
+
+void loop(){
+  // Loop and read the count
+  //Serial.printf("Encoder count = %lld\n", encoder.getCount());
+  display.clearDisplay();
+  display.setCursor(0,0);
+  display.printf("E: %lld\n", encoder.getCount());
+  display.display();
+  delay(500);
+  ESP_LOGD(LOG_TAG, "loop");
+}

--- a/src/ESP32Encoder.h
+++ b/src/ESP32Encoder.h
@@ -19,11 +19,21 @@ enum puType {
 	NONE
 };
 
-typedef void (*enc_isr_cb_t)(void);
+class ESP32Encoder;
+
+typedef void (*enc_isr_cb_t)(ESP32Encoder*);
 
 class ESP32Encoder {
 public:
-	ESP32Encoder(bool always_interrupt=false,  enc_isr_cb_t=nullptr);
+	/**
+	 * @brief Construct a new ESP32Encoder object
+	 * 
+	 * @param always_interrupt set to true to enable interrupt on every encoder pulse, otherwise false
+	 * @param enc_isr_cb callback executed on every encoder ISR, gets a pointer to
+	 * 	the ESP32Encoder instance as an argument, no effect if always_interrupt is
+	 * 	false 
+	 */
+	ESP32Encoder(bool always_interrupt=false, enc_isr_cb_t enc_isr_cb=nullptr);
 	~ESP32Encoder();
 	void attachHalfQuad(int aPintNumber, int bPinNumber);
 	void attachFullQuad(int aPintNumber, int bPinNumber);

--- a/src/ESP32Encoder.h
+++ b/src/ESP32Encoder.h
@@ -17,19 +17,8 @@ DOWN,
 NONE
 };
 class ESP32Encoder {
-private:
-	void attach(int aPintNumber, int bPinNumber, enum encType et);
-	boolean attached=false;
-
-
-	static  pcnt_isr_handle_t user_isr_handle; //user's ISR service handle
-    bool direction;
-    bool working;
-
-	static bool attachedInterrupt;
-	int64_t getCountRaw();
 public:
-	ESP32Encoder();
+	ESP32Encoder(bool always_interrupt=false);
 	~ESP32Encoder();
 	void attachHalfQuad(int aPintNumber, int bPinNumber);
 	void attachFullQuad(int aPintNumber, int bPinNumber);
@@ -43,6 +32,7 @@ public:
 	void setCount(int64_t value);
 	void setFilter(uint16_t value);
 	static ESP32Encoder *encoders[MAX_ESP32_ENCODERS];
+	bool always_interrupt;
 	gpio_num_t aPinNumber;
 	gpio_num_t bPinNumber;
 	pcnt_unit_t unit;
@@ -51,6 +41,15 @@ public:
 	volatile int64_t count=0;
 	pcnt_config_t r_enc_config;
 	static enum puType useInternalWeakPullResistors;
+
+private:
+	static  pcnt_isr_handle_t user_isr_handle;
+	static bool attachedInterrupt;
+	void attach(int aPintNumber, int bPinNumber, enum encType et);
+	int64_t getCountRaw();
+	bool attached;
+  bool direction;
+  bool working;
 };
 
 //Added by Sloeber 

--- a/src/ESP32Encoder.h
+++ b/src/ESP32Encoder.h
@@ -6,19 +6,24 @@
 #define 	_INT16_MAX 32766
 #define  	_INT16_MIN -32766
 
+
 enum encType {
-single,
-half,
-full
+	single,
+	half,
+	full
 };
+
 enum puType {
-UP,
-DOWN,
-NONE
+	UP,
+	DOWN,
+	NONE
 };
+
+typedef void (*enc_isr_cb_t)(void);
+
 class ESP32Encoder {
 public:
-	ESP32Encoder(bool always_interrupt=false);
+	ESP32Encoder(bool always_interrupt=false,  enc_isr_cb_t=nullptr);
 	~ESP32Encoder();
 	void attachHalfQuad(int aPintNumber, int bPinNumber);
 	void attachFullQuad(int aPintNumber, int bPinNumber);
@@ -41,6 +46,7 @@ public:
 	volatile int64_t count=0;
 	pcnt_config_t r_enc_config;
 	static enum puType useInternalWeakPullResistors;
+	enc_isr_cb_t _enc_isr_cb;
 
 private:
 	static  pcnt_isr_handle_t user_isr_handle;

--- a/src/ESP32Encoder.h
+++ b/src/ESP32Encoder.h
@@ -27,11 +27,11 @@ class ESP32Encoder {
 public:
 	/**
 	 * @brief Construct a new ESP32Encoder object
-	 * 
+	 *
 	 * @param always_interrupt set to true to enable interrupt on every encoder pulse, otherwise false
 	 * @param enc_isr_cb callback executed on every encoder ISR, gets a pointer to
 	 * 	the ESP32Encoder instance as an argument, no effect if always_interrupt is
-	 * 	false 
+	 * 	false
 	 */
 	ESP32Encoder(bool always_interrupt=false, enc_isr_cb_t enc_isr_cb=nullptr);
 	~ESP32Encoder();
@@ -68,6 +68,6 @@ private:
   bool working;
 };
 
-//Added by Sloeber 
+//Added by Sloeber
 #pragma once
 


### PR DESCRIPTION
Ctor accepts two parameters so interrupts will be generated on every pulse. Tested with a common rotary encoder connected with 1K resistors to pins 4 and 5 and ESP32

This allows to send messages on encoder rotations to other tasks etc, without having to poll for the encoder or rework the main ISR code dealing with the pulse counters.

```
static IRAM_ATTR void enc_cb(ESP32Encoder* enc) {
  Serial.printf("enc cb: count: %d\n", enc->getCount());
  static bool leds = false;
  digitalWrite(LED_BUILTIN, (int)leds);
  leds = !leds;
}

[...]
ESP32Encoder encoder(true, enc_cb);
```