### PR TITLE
Fix concurrency issues, three separate fixes are needed together:

### DIFF
--- a/src/ESP32Encoder.h
+++ b/src/ESP32Encoder.h
@@ -5,7 +5,7 @@
 #define MAX_ESP32_ENCODERS PCNT_UNIT_MAX
 #define 	_INT16_MAX 32766
 #define  	_INT16_MIN -32766
-
+#define ISR_CORE_USE_DEFAULT (0xffffffff)
 
 enum encType {
 	single,
@@ -56,6 +56,7 @@ public:
 	volatile int64_t count=0;
 	pcnt_config_t r_enc_config;
 	static enum puType useInternalWeakPullResistors;
+	static uint32_t isrServiceCpuCore;
 	enc_isr_cb_t _enc_isr_cb;
 	void* _enc_isr_cb_data;
 


### PR DESCRIPTION
New PR after feedback, code only 

Resolves #69 


- use same core to service ISR as the reader is using
- use spinlock around modifying the count
- use a reread and compensate if interrupt was triggered
