### PR TITLE
Allow compilation on esp32c3

### DIFF
--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -6,6 +6,9 @@
  */
 
 #include <ESP32Encoder.h>
+#include <soc/soc_caps.h>
+#if SOC_PCNT_SUPPORTED
+// Not all esp32 chips support the pcnt (notably the esp32c3 does not)
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
@@ -303,3 +306,6 @@ void ESP32Encoder::setFilter(uint16_t value) {
 	}
 
 }
+#else
+#warning PCNT not supported on this SoC, this will likely lead to linker errors when using ESP32Encoder
+#endif // SOC_PCNT_SUPPORTED


### PR DESCRIPTION
This pull request allows to compile the library on esp32c3, by checking SOC_PCNT_SUPPORTED from soc_cps.h to check whether this SoC supports the PCNT.

That means the `InterruptEncoder` can be used on that platform. Using the `ESP32Encoder` will lead to a linker error.

> An alternative implementation (let me know if you think this is more elegant, then I will fix the pull request) is to include `<soc_caps.h>` in `ESP32Encoder.h` and simply also hide all the declarations (and all the implementation code in the cpp file) if the PCNT isn't supported.

Aside from allowing use of the InterruptEncoder in the esp32c3 this pull request solves another problem for me (and possibly others): platformio does not allow you to specify dependencies for one variant of the esp32 but not for another. So, if you specify (in `library.json`) your library needs the `ESP32Encoder` library it will be included and built for all esp32 variants. Which will fail on the esp32c3 (without this pull request).