### PR TITLE
Fix compile error (Arduino 2.0.14)

### DIFF
--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,8 +12,10 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
-#include <freertos/FreeRTOS.h>
-#include <rom/gpio.h>
+#if ESP_IDF_VERSION_MAJOR == 5
+	#include <freertos/FreeRTOS.h>
+	#include <rom/gpio.h>
+#endif
 
 static const char* TAG_ENCODER = "ESP32Encoder";
 

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <ESP32Encoder.h>
+#include <Arduino.h>
 #include <soc/soc_caps.h>
 #if SOC_PCNT_SUPPORTED
 // Not all esp32 chips support the pcnt (notably the esp32c3 does not)

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,6 +12,8 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
+#include <freertos/FreeRTOS.h>
+#include <rom/gpio.h>
 
 static const char* TAG_ENCODER = "ESP32Encoder";
 

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,7 +12,7 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
-#if ESP_IDF_VERSION_MAJOR == 5
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
 	#include <freertos/FreeRTOS.h>
 	#include <rom/gpio.h>
 #endif


### PR DESCRIPTION
Fix this compile error (Arduino 2.0.14):

```
Compiling .pio\build\lolin_d32_pro_sdmmc_pe\lib8df\ESP32Encoder\ESP32Encoder.cpp.o
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp: In member function 'void ESP32Encoder::attach(int, int, encType)':
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp:140:4: error: 'delay' was not declared in this scope
    delay(100);
    ^~~~~
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp:140:4: note: suggested alternative: 'detach'
    delay(100);
    ^~~~~
    detach
```