### PR TITLE
Fix warnings: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]

### DIFF
--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,8 +12,10 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
-#include <freertos/FreeRTOS.h>
-#include <rom/gpio.h>
+#if ESP_IDF_VERSION_MAJOR == 5
+	#include <freertos/FreeRTOS.h>
+	#include <rom/gpio.h>
+#endif
 
 static const char* TAG_ENCODER = "ESP32Encoder";
 

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <ESP32Encoder.h>
+#include <Arduino.h>
 #include <soc/soc_caps.h>
 #if SOC_PCNT_SUPPORTED
 // Not all esp32 chips support the pcnt (notably the esp32c3 does not)

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -83,15 +83,15 @@ static void esp32encoder_pcnt_intr_handler(void *arg) {
 	pcnt_unit_t unit = esp32enc->r_enc_config.unit;
 	_ENTER_CRITICAL();
 	if(PCNT.status_unit[unit].COUNTER_H_LIM){
-		esp32enc->count += esp32enc->r_enc_config.counter_h_lim;
+		esp32enc->count = esp32enc->count + esp32enc->r_enc_config.counter_h_lim;
 		pcnt_counter_clear(unit);
 	} else if(PCNT.status_unit[unit].COUNTER_L_LIM){
-		esp32enc->count += esp32enc->r_enc_config.counter_l_lim;
+		esp32enc->count = esp32enc->count + esp32enc->r_enc_config.counter_l_lim;
 		pcnt_counter_clear(unit);
 	} else if(esp32enc->always_interrupt && (PCNT.status_unit[unit].thres0_lat || PCNT.status_unit[unit].thres1_lat)) {
 		int16_t c;
 		pcnt_get_counter_value(unit, &c);
-		esp32enc->count += c;
+		esp32enc->count = esp32enc->count + c;
 		pcnt_set_event_value(unit, PCNT_EVT_THRES_0, -1);
 		pcnt_set_event_value(unit, PCNT_EVT_THRES_1, 1);
 		pcnt_event_enable(unit, PCNT_EVT_THRES_0);

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,6 +12,8 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
+#include <freertos/FreeRTOS.h>
+#include <rom/gpio.h>
 
 static const char* TAG_ENCODER = "ESP32Encoder";
 

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,7 +12,7 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
-#if ESP_IDF_VERSION_MAJOR == 5
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
 	#include <freertos/FreeRTOS.h>
 	#include <rom/gpio.h>
 #endif


### PR DESCRIPTION
First: Thank's for your library & everythings works fine also for for upcoming Arduino 3!


While compiling your library with Arduino 3 (ESP-IDF5.1)  i get some mostly harmless warnings.
Compiled with PlatformIO and these compiler flags:

```
build_flags =
    -std=c++17
    -std=gnu++17
    -Wall
    -Wextra
    -Wunreachable-code
````

```

.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp: In function 'void esp32encoder_pcnt_intr_handler(void*)':
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp:86:33: warning: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]
   86 |                 esp32enc->count += esp32enc->r_enc_config.counter_h_lim;
      |                 ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp:89:33: warning: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]
   89 |                 esp32enc->count += esp32enc->r_enc_config.counter_l_lim;
      |                 ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/ESP32Encoder.cpp:94:33: warning: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]
   94 |                 esp32enc->count += c;
      |                 ~~~~~~~~~~~~~~~~^~~~


```
This PR fixes the warnings above. One warning left, don't know how to fix: ;-(

```
C:/Users/dcars/.platformio/packages/framework-arduinoespressif32-libs/esp32/include/driver/deprecated/driver/pcnt.h:15:2: warning: #warning "legacy pcnt driver is deprecated, please migrate to use driver/pulse_cnt.h" [-Wcpp]
   15 | #warning "legacy pcnt driver is deprecated, please migrate to use driver/pulse_cnt.h"

```