### PR TITLE
Fix warning encoderAISR:: '++'/'--' expression of 'volatile'-qualified type is deprecated [-Wvolatile]

### DIFF
--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,8 +12,10 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
-#include <freertos/FreeRTOS.h>
-#include <rom/gpio.h>
+#if ESP_IDF_VERSION_MAJOR == 5
+	#include <freertos/FreeRTOS.h>
+	#include <rom/gpio.h>
+#endif
 
 static const char* TAG_ENCODER = "ESP32Encoder";
 

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <ESP32Encoder.h>
+#include <Arduino.h>
 #include <soc/soc_caps.h>
 #if SOC_PCNT_SUPPORTED
 // Not all esp32 chips support the pcnt (notably the esp32c3 does not)

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -83,15 +83,15 @@ static void esp32encoder_pcnt_intr_handler(void *arg) {
 	pcnt_unit_t unit = esp32enc->r_enc_config.unit;
 	_ENTER_CRITICAL();
 	if(PCNT.status_unit[unit].COUNTER_H_LIM){
-		esp32enc->count += esp32enc->r_enc_config.counter_h_lim;
+		esp32enc->count = esp32enc->count + esp32enc->r_enc_config.counter_h_lim;
 		pcnt_counter_clear(unit);
 	} else if(PCNT.status_unit[unit].COUNTER_L_LIM){
-		esp32enc->count += esp32enc->r_enc_config.counter_l_lim;
+		esp32enc->count = esp32enc->count + esp32enc->r_enc_config.counter_l_lim;
 		pcnt_counter_clear(unit);
 	} else if(esp32enc->always_interrupt && (PCNT.status_unit[unit].thres0_lat || PCNT.status_unit[unit].thres1_lat)) {
 		int16_t c;
 		pcnt_get_counter_value(unit, &c);
-		esp32enc->count += c;
+		esp32enc->count = esp32enc->count + c;
 		pcnt_set_event_value(unit, PCNT_EVT_THRES_0, -1);
 		pcnt_set_event_value(unit, PCNT_EVT_THRES_1, 1);
 		pcnt_event_enable(unit, PCNT_EVT_THRES_0);

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,6 +12,8 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
+#include <freertos/FreeRTOS.h>
+#include <rom/gpio.h>
 
 static const char* TAG_ENCODER = "ESP32Encoder";
 

--- a/src/ESP32Encoder.cpp
+++ b/src/ESP32Encoder.cpp
@@ -12,7 +12,7 @@
 #include <soc/pcnt_struct.h>
 #include "esp_log.h"
 #include "esp_ipc.h"
-#if ESP_IDF_VERSION_MAJOR == 5
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
 	#include <freertos/FreeRTOS.h>
 	#include <rom/gpio.h>
 #endif

--- a/src/InterruptEncoder.cpp
+++ b/src/InterruptEncoder.cpp
@@ -15,9 +15,9 @@ void IRAM_ATTR encoderAISR(void * arg) {
 		object->aState = digitalRead(object->apin);
 		object->bState = digitalRead(object->bpin);
 		if (object->aState == object->bState)
-			object->count++;
+			object->count = object->count + 1;
 		else
-			object->count--;
+			object->count = object->count - 1;
 	}
 }
 InterruptEncoder::InterruptEncoder() {}


### PR DESCRIPTION
Sorry to make another PR, just seen that there is another warn message with upcoming Arduino 3 (ESP-IDF 5.x):

```
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/InterruptEncoder.cpp: In function 'void encoderAISR(void*)':
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/InterruptEncoder.cpp:18:33: warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
   18 |                         object->count++;
      |                         ~~~~~~~~^~~~~
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP32Encoder/src/InterruptEncoder.cpp:20:33: warning: '--' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
   20 |                         object->count--;
      |                         ~~~~~~~~^~~~~
```

This PR fixes the compiler warnings, best regards
Dirk