### PR TITLE
IDF v5.xx changed API to pulse_cnt.h

### DIFF
--- a/src/ESP32Encoder.h
+++ b/src/ESP32Encoder.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <driver/gpio.h>
-#include <driver/pcnt.h>
+#include <driver/pulse_cnt.h>
 #ifndef ARDUINO
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>


### PR DESCRIPTION
#warning "legacy pcnt driver is deprecated, please migrate to use driver/pulse_cnt.h"